### PR TITLE
Don't crash because TRNSYS dir is now a path.

### DIFF
--- a/trnsysGUI/GUI.py
+++ b/trnsysGUI/GUI.py
@@ -256,6 +256,10 @@ class MainWindow(QMainWindow):
         debugConnections.triggered.connect(self.debugConns)
         self.fileMenu.addAction(debugConnections)
 
+        setTransysPath = QAction("Set TRNSYS path", self)
+        setTransysPath.triggered.connect(self.askUserForSettingsValuesAndSave)
+        self.fileMenu.addAction(setTransysPath)
+
         self.editMenu = QMenu("Edit")
         self.editMenu.addAction(toggleSnapAction)
         self.editMenu.addAction(toggleAlignModeAction)
@@ -793,12 +797,12 @@ class MainWindow(QMainWindow):
         self.logger.info(exportPath)
         if exportPath != "None":
             msgb = QMessageBox(self)
-            if not os.path.isfile(self.centralWidget.trnsysPath):
-                msgb.setText("TRNExe.exe not found!")
+            if not self.centralWidget.trnsysPath.is_file():
+                msgb.setText("TRNExe.exe not found! Consider correcting the path in the settings.")
                 msgb.exec()
                 return 0, 0
-            self.logger.info("trnsyspath: " + self.centralWidget.trnsysPath)
-            cmd = self.centralWidget.trnsysPath + " " + str(exportPath) + r" /H"
+            self.logger.info("trnsyspath: %s", self.centralWidget.trnsysPath)
+            cmd = f"{self.centralWidget.trnsysPath} {exportPath} /H"
             os.system(cmd)
             mfrFile = os.path.join(self.projectFolder, self.projectFolder.split("\\")[-1] + "_Mfr.prt")
             tempFile = os.path.join(self.projectFolder, self.projectFolder.split("\\")[-1] + "_T.prt")
@@ -909,11 +913,13 @@ class MainWindow(QMainWindow):
     def ensureSettingsExist(self):
         settings = _settings.Settings.tryLoadOrNone()
         if not settings:
-            newSettings = _sdlg.SettingsDlg.showDialogAndGetSettings(parent=self)
-            while newSettings == _sdlg.CANCELLED:
-                newSettings = _sdlg.SettingsDlg.showDialogAndGetSettings(parent=self)
+            self.askUserForSettingsValuesAndSave()
 
-            newSettings.save()
+    def askUserForSettingsValuesAndSave(self):
+        newSettings = _sdlg.SettingsDlg.showDialogAndGetSettings(parent=self)
+        while newSettings == _sdlg.CANCELLED:
+            newSettings = _sdlg.SettingsDlg.showDialogAndGetSettings(parent=self)
+        newSettings.save()
 
     def loadTrnsysPath(self):
         settings = _settings.Settings.load()

--- a/trnsysGUI/diagram/Editor.py
+++ b/trnsysGUI/diagram/Editor.py
@@ -205,7 +205,7 @@ class Editor(QWidget):
         self.snapGrid = False
         self.snapSize = 20
 
-        self.trnsysPath = "C:\Trnsys17\Exe\TRNExe.exe"
+        self.trnsysPath = pl.Path(r"C:\Trnsys17\Exe\TRNExe.exe")
 
         self.horizontalLayout = QHBoxLayout(self)
         self.libraryBrowserView = QListView(self)

--- a/trnsysGUI/settingsDlg.py
+++ b/trnsysGUI/settingsDlg.py
@@ -28,8 +28,8 @@ class SettingsDlg(_widgets.QDialog):
         oldTrnsysPath = settings.trnsysBinaryDirPath if settings else ""
 
         label = _widgets.QLabel("Trnsys Path:")
-        self.lineEdit = _widgets.QLineEdit(oldTrnsysPath)
-        self.lineEdit.setDisabled(True)
+        self._lineEdit = _widgets.QLineEdit(oldTrnsysPath)
+        self._lineEdit.setDisabled(True)
 
         setButton = _widgets.QPushButton("Set Trnsys Path")
         setButton.setFixedWidth(100)
@@ -37,7 +37,7 @@ class SettingsDlg(_widgets.QDialog):
 
         layout = _widgets.QHBoxLayout()
         layout.addWidget(label)
-        layout.addWidget(self.lineEdit)
+        layout.addWidget(self._lineEdit)
         layout.addWidget(setButton)
 
         self._okButton = _widgets.QPushButton("Done")
@@ -69,20 +69,26 @@ class SettingsDlg(_widgets.QDialog):
         return _settings.Settings.tryLoadOrNone()
 
     def _onSetButtonClicked(self) -> None:
-        newTrnsysPath = str(_widgets.QFileDialog.getExistingDirectory(self, "Select Trnsys Path"))
-        self.lineEdit.setText(newTrnsysPath)
+        oldDirPath = self._lineEdit.text()
 
-        canOk = True if self._getSettings() or newTrnsysPath else False
+        newBinaryPath, _ = _widgets.QFileDialog.getOpenFileName(
+            self, "Select TRNSYS exe", directory=oldDirPath, filter="*.exe"
+        )
+
+        newDirPath = str(_pl.Path(newBinaryPath).parent)
+        self._lineEdit.setText(newDirPath)
+
+        canOk = True if self._getSettings() or newDirPath else False
         self._okButton.setEnabled(canOk)
 
     def _onOkButtonClicked(self) -> None:
-        newTrnsysPath = self.lineEdit.text()
+        newDirPath = self._lineEdit.text()
 
         settings = self._getSettings()
         if settings:
-            settings.trnsysBinaryDirPath = newTrnsysPath
+            settings.trnsysBinaryDirPath = newDirPath
         else:
-            settings = _settings.Settings.create(_pl.Path(newTrnsysPath))
+            settings = _settings.Settings.create(_pl.Path(newDirPath))
 
         self._settings = settings
 


### PR DESCRIPTION
- Also make the user select the TRNSYS exe so it's clearer which directory we're asking for.