### PR TITLE
Support new and legacy port ID names.

### DIFF
--- a/trnsysGUI/Connection.py
+++ b/trnsysGUI/Connection.py
@@ -1385,9 +1385,9 @@ class ConnectionModelVersion0(_ser.UpgradableJsonSchemaMixinVersion0):
     def getVersion(cls) -> _uuid.UUID:
         return _uuid.UUID('7a15d665-f634-4037-b5af-3662b487a214')
 
+
 @_dc.dataclass
 class ConnectionModel(_ser.UpgradableJsonSchemaMixin):
-
     connectionId: int
     name: str
     id: int


### PR DESCRIPTION
Since we're outside the `Connection` we can't make use of our "upgrade-aware" serialization mini-framework and have to manually check for both possible
ways port IDs can be named.