### PR TITLE
Use absolute file path to executable with `subprocessing`.

### DIFF
--- a/dev-tools/generateGuiClassesFromQtCreatorStudioUiFiles.py
+++ b/dev-tools/generateGuiClassesFromQtCreatorStudioUiFiles.py
@@ -4,17 +4,22 @@
 
 import pathlib as _pl
 import subprocess as _sp
+import shutil as _su
 
 
 def main():
+    pyuicExecutableFilePath = _su.which("pyuic5")
+
+    print(f"Using `pyuic5' executable at {pyuicExecutableFilePath}")
+
     currentDirPath = _pl.Path()
     uiFilePaths = currentDirPath.rglob("*.ui")
     for uiFilePath in uiFilePaths:
         generatedFileName = f"_UI_{uiFilePath.with_suffix('').name}_generated.py"
         generatedFilePath = uiFilePath.with_name(generatedFileName)
         print(f"Generating {generatedFilePath} from {uiFilePath}...", end="")
-        cmd = ["pyuic5", str(uiFilePath), "-o", str(generatedFilePath)]
-        _sp.run(cmd, shell=True, check=True)
+        cmd = [pyuicExecutableFilePath, "-o", generatedFilePath, uiFilePath]
+        _sp.run(cmd, check=True)
         print("done.")
 
 


### PR DESCRIPTION
More portable this way: also works on Linux and not only on Windows.