### PR TITLE
Don't allow starting connections from already connected port.

### DIFF
--- a/trnsysGUI/PortItemBase.py
+++ b/trnsysGUI/PortItemBase.py
@@ -216,9 +216,13 @@ class PortItemBase(QGraphicsEllipseItem):
         if self.parent.parent.parent().moveDirectPorts and hasattr(self.parent, "heatExchangers"):
             self.setFlag(self.ItemIsMovable)
             self.savePos = self.pos()
-        else:
-            self.setFlag(self.ItemIsMovable, False)
-            self.scene().parent().startConnection(self)
+            return
+
+        if self.connectionList:
+            return
+        
+        self.setFlag(self.ItemIsMovable, False)
+        self.scene().parent().startConnection(self)
 
     def hoverEnterEvent(self, event):
         # self.logger.debug("Hovering")


### PR DESCRIPTION
Previously, we'd crash if one were to try to connect from an already connected port. Now, you can't drag from such a port.