### PR TITLE
Move `massFlowSolver` to `trnsysGUI`.

### DIFF
--- a/trnsysGUI/AirSourceHP.py
+++ b/trnsysGUI/AirSourceHP.py
@@ -7,9 +7,9 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView

--- a/trnsysGUI/BlockItemFourPorts.py
+++ b/trnsysGUI/BlockItemFourPorts.py
@@ -4,9 +4,9 @@
 import glob
 import os
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 
 

--- a/trnsysGUI/Boiler.py
+++ b/trnsysGUI/Boiler.py
@@ -5,11 +5,9 @@ import os
 import shutil
 import typing as _tp
 
-from PyQt5.QtCore import QSize
-from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QTreeView
 
-from massFlowSolver import MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView

--- a/trnsysGUI/Collector.py
+++ b/trnsysGUI/Collector.py
@@ -7,9 +7,9 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView

--- a/trnsysGUI/Connector.py
+++ b/trnsysGUI/Connector.py
@@ -4,8 +4,8 @@
 import typing as _tp
 
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
-from massFlowSolver.networkModel import Pipe, PortItem
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver.networkModel import Pipe, PortItem
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 

--- a/trnsysGUI/Export.py
+++ b/trnsysGUI/Export.py
@@ -4,7 +4,7 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QMessageBox
 
-import massFlowSolver as _mfs  # type: ignore[attr-defined]
+from trnsysGUI import massFlowSolver as _mfs
 from trnsysGUI.connection.connectionBase import ConnectionBase  # type: ignore[attr-defined]
 from trnsysGUI.TVentil import TVentil  # type: ignore[attr-defined]
 from trnsysGUI.connection.doublePipeConnection import DoublePipeConnection

--- a/trnsysGUI/GenericBlock.py
+++ b/trnsysGUI/GenericBlock.py
@@ -8,10 +8,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QMenu, QFileDialog, QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 from trnsysGUI.singlePipePortItem import SinglePipePortItem

--- a/trnsysGUI/GroundSourceHx.py
+++ b/trnsysGUI/GroundSourceHx.py
@@ -7,10 +7,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver as _mfs
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView

--- a/trnsysGUI/HPDoubleDual.py
+++ b/trnsysGUI/HPDoubleDual.py
@@ -8,10 +8,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 from trnsysGUI.singlePipePortItem import SinglePipePortItem

--- a/trnsysGUI/HPDual.py
+++ b/trnsysGUI/HPDual.py
@@ -8,10 +8,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 from trnsysGUI.singlePipePortItem import SinglePipePortItem

--- a/trnsysGUI/HeatPump.py
+++ b/trnsysGUI/HeatPump.py
@@ -8,10 +8,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 

--- a/trnsysGUI/HeatPumpTwoHx.py
+++ b/trnsysGUI/HeatPumpTwoHx.py
@@ -7,10 +7,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 from trnsysGUI.singlePipePortItem import SinglePipePortItem

--- a/trnsysGUI/IceStorage.py
+++ b/trnsysGUI/IceStorage.py
@@ -7,8 +7,8 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-import massFlowSolver.networkModel as _mfn
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+import trnsysGUI.massFlowSolver.networkModel as _mfn
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView

--- a/trnsysGUI/PortItemBase.py
+++ b/trnsysGUI/PortItemBase.py
@@ -11,8 +11,8 @@ from PyQt5.QtGui import QColor, QBrush, QCursor, QPen
 from PyQt5.QtWidgets import QGraphicsEllipseItem
 
 if _tp.TYPE_CHECKING:
-    import massFlowSolver.networkModel as _mfn
-    import massFlowSolver as _mfs
+    import trnsysGUI.massFlowSolver.networkModel as _mfn
+    import trnsysGUI.massFlowSolver as _mfs
     import trnsysGUI.connection.connectionBase as _cb
 
 

--- a/trnsysGUI/Pump.py
+++ b/trnsysGUI/Pump.py
@@ -5,9 +5,9 @@ import typing as _tp
 
 import numpy as np
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 

--- a/trnsysGUI/Radiator.py
+++ b/trnsysGUI/Radiator.py
@@ -7,14 +7,14 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QTreeView
 
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 import trnsysGUI.images as _img
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 
 
 class Radiator(BlockItem, MassFlowNetworkContributorMixin):

--- a/trnsysGUI/TVentil.py
+++ b/trnsysGUI/TVentil.py
@@ -5,10 +5,10 @@ import typing as _tp
 
 from PyQt5.QtWidgets import QGraphicsTextItem
 
-import massFlowSolver as _mfs
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 

--- a/trnsysGUI/TeePiece.py
+++ b/trnsysGUI/TeePiece.py
@@ -3,10 +3,10 @@
 
 import typing as _tp
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 
 

--- a/trnsysGUI/WTap.py
+++ b/trnsysGUI/WTap.py
@@ -8,9 +8,9 @@ import typing as _tp
 from PyQt5.QtWidgets import QTreeView
 
 import trnsysGUI.images as _img
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.MyQFileSystemModel import MyQFileSystemModel
 from trnsysGUI.MyQTreeView import MyQTreeView
 from trnsysGUI.singlePipePortItem import SinglePipePortItem

--- a/trnsysGUI/WTap_main.py
+++ b/trnsysGUI/WTap_main.py
@@ -3,10 +3,10 @@
 
 import typing as _tp
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 from trnsysGUI.BlockItem import BlockItem
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.singlePipePortItem import SinglePipePortItem
 
 

--- a/trnsysGUI/connection/connectionBase.py
+++ b/trnsysGUI/connection/connectionBase.py
@@ -10,8 +10,8 @@ from PyQt5.QtCore import QPointF
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QGraphicsTextItem, QUndoCommand
 
-import massFlowSolver as _mfs
-from massFlowSolver import InternalPiping
+import trnsysGUI.massFlowSolver as _mfs
+from trnsysGUI.massFlowSolver import InternalPiping
 from trnsysGUI import idGenerator as _id
 from trnsysGUI.CornerItem import CornerItem
 from trnsysGUI.Node import Node

--- a/trnsysGUI/connection/doublePipeConnection.py
+++ b/trnsysGUI/connection/doublePipeConnection.py
@@ -8,13 +8,14 @@ import PyQt5.QtWidgets as _qtw
 
 import dataclasses_jsonschema as _dcj
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.serialization as _ser
-from massFlowSolver import InternalPiping  # type: ignore[attr-defined]
+from trnsysGUI.massFlowSolver import InternalPiping  # type: ignore[attr-defined]
 from trnsysGUI.PortItemBase import PortItemBase  # type: ignore[attr-defined]
 from trnsysGUI.connection.connectionBase import ConnectionBase  # type: ignore[attr-defined]
 from trnsysGUI.doublePipeSegmentItem import DoublePipeSegmentItem
 from trnsysGUI.doublePipeModelPortItems import ColdPortItem, HotPortItem
+
 
 class DoublePipeConnection(ConnectionBase):
     def __init__(self, fromPort: PortItemBase, toPort: PortItemBase, parent):

--- a/trnsysGUI/connection/singlePipeConnection.py
+++ b/trnsysGUI/connection/singlePipeConnection.py
@@ -11,8 +11,8 @@ import dataclasses_jsonschema as _dcj
 
 import PyQt5.QtWidgets as _qtw
 
-import massFlowSolver as _mfs
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.PortItemBase as _pib
 import trnsysGUI.connection.connectionBase as _cb
 import trnsysGUI.serialization as _ser

--- a/trnsysGUI/crystalizer.py
+++ b/trnsysGUI/crystalizer.py
@@ -1,10 +1,10 @@
 import typing as _tp
 
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem  # type: ignore[attr-defined]
 from trnsysGUI.singlePipePortItem import SinglePipePortItem  # type: ignore[attr-defined]
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 
 
 class Crystalizer(BlockItem, MassFlowNetworkContributorMixin):

--- a/trnsysGUI/diagram/Editor.py
+++ b/trnsysGUI/diagram/Editor.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
 )
 
-import massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver as _mfs
 import pytrnsys.trnsys_util.deckUtils as _du
 import trnsysGUI as _tgui
 import trnsysGUI.errors as _errs

--- a/trnsysGUI/doubleDoublePipeConnector.py
+++ b/trnsysGUI/doubleDoublePipeConnector.py
@@ -1,8 +1,8 @@
 import typing as _tp
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping
+from trnsysGUI.massFlowSolver import InternalPiping
 from trnsysGUI.doublePipeConnectorBase import DoublePipeConnectorBase
 from trnsysGUI.doublePipePortItem import DoublePipePortItem  # type: ignore[attr-defined]
 from trnsysGUI.doublePipeModelPortItems import ColdPortItem, HotPortItem

--- a/trnsysGUI/doublePipeConnectorBase.py
+++ b/trnsysGUI/doublePipeConnectorBase.py
@@ -6,7 +6,7 @@ import dataclasses_jsonschema as _dcj
 
 import trnsysGUI.images as _img
 import trnsysGUI.serialization as _ser
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem  # type: ignore[attr-defined]
 
 

--- a/trnsysGUI/doublePipeModelPortItems.py
+++ b/trnsysGUI/doublePipeModelPortItems.py
@@ -1,7 +1,9 @@
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
+
 
 class ColdPortItem(_mfn.PortItem):
     pass
+
 
 class HotPortItem(_mfn.PortItem):
     pass

--- a/trnsysGUI/doublePipePortItem.py
+++ b/trnsysGUI/doublePipePortItem.py
@@ -1,7 +1,7 @@
 import typing as _tp
 
-import massFlowSolver as _mfs
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.PortItemBase as _pi
 import trnsysGUI.doublePipeModelPortItems as _dpmpi
 

--- a/trnsysGUI/doublePipeTeePiece.py
+++ b/trnsysGUI/doublePipeTeePiece.py
@@ -2,9 +2,9 @@
 
 import typing as _tp
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem  # type: ignore[attr-defined]
 from trnsysGUI.doublePipePortItem import DoublePipePortItem  # type: ignore[attr-defined]
 from trnsysGUI.doublePipeConnectorBase import DoublePipeBlockItemModel

--- a/trnsysGUI/hydraulicLoops/_search.py
+++ b/trnsysGUI/hydraulicLoops/_search.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import typing as _tp
 
-import massFlowSolver as _mfs
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.connection.singlePipeConnection as _spc
 import trnsysGUI.singlePipePortItem as _spi
 

--- a/trnsysGUI/massFlowSolver/networkModel.py
+++ b/trnsysGUI/massFlowSolver/networkModel.py
@@ -45,7 +45,9 @@ class Parameters:
     neighbourIndices: _tp.Tuple[int, int, int]
 
     def toString(self, secondColumnIndent: int) -> str:
-        firstColumn = f"{self.neighbourIndices[0]} {self.neighbourIndices[1]} {self.neighbourIndices[2]} {self.nodeType} "
+        firstColumn = (
+            f"{self.neighbourIndices[0]} {self.neighbourIndices[1]} {self.neighbourIndices[2]} {self.nodeType} "
+        )
         secondColumn = f"!{self.index} : {self.name}"
 
         line = f"{firstColumn.ljust(secondColumnIndent)}{secondColumn}"
@@ -93,14 +95,14 @@ class PortItem(NodeBase, _abc.ABC):
         return f"<PortItem object at 0x{id(self):x}>"
 
 
-@_dc.dataclass(eq=False)
+@_dc.dataclass(eq=False)  # type: ignore[misc]
 class RealNodeBase(NodeBase, _abc.ABC):
     name: str
     trnsysId: int
 
     def serialize(self, nodesToIndices: _tp.Mapping[NodeBase, int]) -> SerializedNode:
         parameters = self._getParameters(nodesToIndices)
-        inputVariable = self._getInputVariable()
+        inputVariable = self._getInputVariable()  # pylint: disable=assignment-from-none
         outputVariables = self._getOutputVariables()
         return SerializedNode(parameters, inputVariable, outputVariables)
 
@@ -117,7 +119,7 @@ class RealNodeBase(NodeBase, _abc.ABC):
     def _getNeighbourIndices(self, nodesToIndices: _tp.Mapping["NodeBase", int]) -> _tp.Tuple[int, int, int]:
         raise NotImplementedError()
 
-    def _getInputVariable(self) -> _tp.Optional[InputVariable]:
+    def _getInputVariable(self) -> _tp.Optional[InputVariable]:  # pylint: disable=no-self-use
         return None
 
     def _getOutputVariables(self) -> OutputVariables:
@@ -138,7 +140,7 @@ class RealNodeBase(NodeBase, _abc.ABC):
         raise NotImplementedError()
 
 
-@_dc.dataclass(eq=False)
+@_dc.dataclass(eq=False)  # type: ignore[misc]
 class OneNeighbourBase(RealNodeBase, _abc.ABC):
     neighbour: NodeBase
 
@@ -173,7 +175,7 @@ class Sink(OneNeighbourBase):
         return 2
 
 
-@_dc.dataclass(eq=False)
+@_dc.dataclass(eq=False)  # type: ignore[misc]
 class TwoNeighboursBase(RealNodeBase, _abc.ABC):
     fromNode: NodeBase
     toNode: NodeBase
@@ -212,7 +214,7 @@ class Pump(TwoNeighboursBase):
         return InputVariable(f"Mfr{self.name}")
 
 
-@_dc.dataclass(eq=False)
+@_dc.dataclass(eq=False)  # type: ignore[misc]
 class ThreeNeighboursBase(RealNodeBase, _abc.ABC):
     node1: NodeBase
     node2: NodeBase

--- a/trnsysGUI/singleDoublePipeConnector.py
+++ b/trnsysGUI/singleDoublePipeConnector.py
@@ -1,8 +1,8 @@
 import typing as _tp
 
-import massFlowSolver.networkModel as _mfn  # type: ignore[attr-defined]
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping
+from trnsysGUI.massFlowSolver import InternalPiping
 from trnsysGUI.doublePipeConnectorBase import DoublePipeConnectorBase
 from trnsysGUI.doublePipePortItem import DoublePipePortItem
 from trnsysGUI.doublePipeModelPortItems import ColdPortItem, HotPortItem

--- a/trnsysGUI/singlePipePortItem.py
+++ b/trnsysGUI/singlePipePortItem.py
@@ -1,7 +1,7 @@
 import typing as _tp
 
-import massFlowSolver as _mfs
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver as _mfs
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 from trnsysGUI.PortItemBase import PortItemBase  # type: ignore[attr-defined]
 
 

--- a/trnsysGUI/sourceSinkBase.py
+++ b/trnsysGUI/sourceSinkBase.py
@@ -1,10 +1,10 @@
 import typing as _tp
 
 import trnsysGUI.images as _img
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI.BlockItem import BlockItem  # type: ignore[attr-defined]
 from trnsysGUI.singlePipePortItem import SinglePipePortItem  # type: ignore[attr-defined]
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 
 
 class SourceSinkBase(BlockItem, MassFlowNetworkContributorMixin):

--- a/trnsysGUI/storageTank/widget.py
+++ b/trnsysGUI/storageTank/widget.py
@@ -7,11 +7,11 @@ import typing as _tp
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QMenu, QMessageBox, QTreeView
 
-import massFlowSolver.networkModel as _mfn
+import trnsysGUI.massFlowSolver.networkModel as _mfn
 import trnsysGUI.images as _img
 import trnsysGUI.storageTank.model as _model
 import trnsysGUI.storageTank.side as _sd
-from massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
+from trnsysGUI.massFlowSolver import InternalPiping, MassFlowNetworkContributorMixin
 from trnsysGUI import idGenerator as _id
 from trnsysGUI.BlockItem import BlockItem  # type: ignore[attr-defined]
 from trnsysGUI.HeatExchanger import HeatExchanger  # type: ignore[attr-defined]


### PR DESCRIPTION
All the code should be under one top-level directory package. `trnsysGUI` might not be the best name for it, but we can always rename it in the future.

Incidentally, because `massFlowSolver` was outside `trnsysGUI` before it wasn't type checked. It automatically is now. That's also why I had to make a few seemingly unrelated changes to satisfy `mypy` and friends.