### PR TITLE
Split build jobs into two distinct workflows.

### DIFF
--- a/.github/workflows/static-checks-and-unit-tests-srspf01.yml
+++ b/.github/workflows/static-checks-and-unit-tests-srspf01.yml
@@ -1,0 +1,44 @@
+name: Static checks and unit tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-srspf01:
+
+    runs-on: srspf01
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel
+        pip install -r requirements/ci/test/requirements.txt
+    - name: Generate UI code from Qt Creator Studio .ui files
+      run: python dev-tools/generateGuiClassesFromQtCreatorStudioUiFiles.py
+    - name: Static type checking with mypy
+      run: python dev-tools/runStaticChecksAndUnitTests.py --type
+    - name: Lint with pylint
+      run: python dev-tools/runStaticChecksAndUnitTests.py --lint --keep-results
+    - name: Generate class and package diagrams
+      run: python dev-tools/runStaticChecksAndUnitTests.py --diagram=dot --keep-results
+    - name: Test with pytest
+      run: python dev-tools/runStaticChecksAndUnitTests.py --unit "linux or linux_ci" --keep-results
+    - name: Upload test results and coverage reports
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results-and-coverage-report-srspf01
+        path: test-results
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}

--- a/.github/workflows/static-checks-and-unit-tests-windows.yml
+++ b/.github/workflows/static-checks-and-unit-tests-windows.yml
@@ -40,43 +40,7 @@ jobs:
     - name: Upload test results and coverage reports
       uses: actions/upload-artifact@v2
       with:
-        name: test-results-and-coverage-report
-        path: test-results
-      # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
-
-  build-srspf01:
-
-    runs-on: srspf01
-    strategy:
-      matrix:
-        python-version: [3.9]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install wheel
-        pip install -r requirements/ci/test/requirements.txt
-    - name: Generate UI code from Qt Creator Studio .ui files
-      run: python dev-tools/generateGuiClassesFromQtCreatorStudioUiFiles.py
-    - name: Static type checking with mypy
-      run: python dev-tools/runStaticChecksAndUnitTests.py --type
-    - name: Lint with pylint
-      run: python dev-tools/runStaticChecksAndUnitTests.py --lint --keep-results
-    - name: Generate class and package diagrams
-      run: python dev-tools/runStaticChecksAndUnitTests.py --diagram=dot --keep-results
-    - name: Test with pytest
-      run: python dev-tools/runStaticChecksAndUnitTests.py --unit "linux or linux_ci" --keep-results
-    - name: Upload test results and coverage reports
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-and-coverage-report
+        name: test-results-and-coverage-report-windows
         path: test-results
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}


### PR DESCRIPTION
Otherwise, they overwrite each other's artifacts.