### PR TITLE
Use `typing.Union` instead of `|` for types that `dataclasses_jsonsch…

### DIFF
--- a/trnsysGUI/connection/values.py
+++ b/trnsysGUI/connection/values.py
@@ -1,4 +1,5 @@
 import dataclasses as _dc
+import typing as _tp
 
 import dataclasses_jsonschema as _dcj
 
@@ -8,7 +9,7 @@ class Variable(_dcj.JsonSchemaMixin):
     name: str
 
 
-Value = Variable | float
+Value = _tp.Union[Variable, float]
 
 
 def getConvertedValueOrName(valueOrName: Value, conversionFactor=1.0) -> float | str:

--- a/trnsysGUI/connection/values.py
+++ b/trnsysGUI/connection/values.py
@@ -9,7 +9,7 @@ class Variable(_dcj.JsonSchemaMixin):
     name: str
 
 
-Value = _tp.Union[Variable, float]
+Value = _tp.Union[Variable, float]  # /NOSONAR
 
 
 def getConvertedValueOrName(valueOrName: Value, conversionFactor=1.0) -> float | str:

--- a/trnsysGUI/hydraulicLoops/_serialization.py
+++ b/trnsysGUI/hydraulicLoops/_serialization.py
@@ -17,8 +17,8 @@ class Variable(_ser.UpgradableJsonSchemaMixinVersion0):
 @_dc.dataclass(frozen=True, eq=False)
 class Fluid(_ser.UpgradableJsonSchemaMixinVersion0):
     name: str
-    specificHeatCapacityInJPerKgK: float | Variable
-    densityInKgPerM3: float | Variable
+    specificHeatCapacityInJPerKgK: _tp.Union[Variable, float]
+    densityInKgPerM3: _tp.Union[Variable, float]
 
     @classmethod
     def getVersion(cls) -> _uuid.UUID:

--- a/trnsysGUI/hydraulicLoops/_serialization.py
+++ b/trnsysGUI/hydraulicLoops/_serialization.py
@@ -17,8 +17,8 @@ class Variable(_ser.UpgradableJsonSchemaMixinVersion0):
 @_dc.dataclass(frozen=True, eq=False)
 class Fluid(_ser.UpgradableJsonSchemaMixinVersion0):
     name: str
-    specificHeatCapacityInJPerKgK: _tp.Union[Variable, float]
-    densityInKgPerM3: _tp.Union[Variable, float]
+    specificHeatCapacityInJPerKgK: _tp.Union[Variable, float]  # /NOSONAR
+    densityInKgPerM3: _tp.Union[Variable, float]  # /NOSONAR
 
     @classmethod
     def getVersion(cls) -> _uuid.UUID:


### PR DESCRIPTION
…ema` needs to understand.

`dataclasses_jsonschema` doesn't understand `|`.