### PR TITLE
Compute `PortItemBase.side` on the fly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,7 @@ _QRC_*_generated.py
 /.idea/
 
 # Virtual environment
-/venv/
-/venv312/
-/venv-stools/
+/venv*/
 
 docs/_build/
 docs/trnsysGUI.uml
@@ -38,5 +36,3 @@ pytrnsys-gui.log
 
 /release/pyinstaller-venv/
 /trnsysGUI/pytrnsys-gui.pyproject.user
-
-/spyder-venv/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ pytrnsys-gui.log
 
 /release/pyinstaller-venv/
 /trnsysGUI/pytrnsys-gui.pyproject.user
+
+/spyder-venv/

--- a/trnsysGUI/AirSourceHP.py
+++ b/trnsysGUI/AirSourceHP.py
@@ -14,8 +14,8 @@ class AirSourceHP(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItem
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
         self.path = ""
 
         self.changeSize()
@@ -62,8 +62,5 @@ class AirSourceHP(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItem
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h

--- a/trnsysGUI/BlockDlg.py
+++ b/trnsysGUI/BlockDlg.py
@@ -51,18 +51,10 @@ class BlockDlg(_ndialog.ChangeNameDialogBase):  # pylint: disable=too-many-insta
 
         self.okButton.clicked.connect(self.acceptedEdit)
         self.cancelButton.clicked.connect(self.cancel)
-        self.hFlipBox.stateChanged.connect(self.setNewFlipStateH)
-        self.vFlipBox.stateChanged.connect(self.setNewFlipStateV)
+        self.hFlipBox.stateChanged.connect(self._blockItem.updateFlipStateH)
+        self.vFlipBox.stateChanged.connect(self._blockItem.updateFlipStateV)
         self.setWindowTitle("Properties")
         self.show()
-
-    def setNewFlipStateH(self, state):
-        self._blockItem.updateFlipStateH(state)
-        self._blockItem.updateSidesFlippedH()
-
-    def setNewFlipStateV(self, state):
-        self._blockItem.updateFlipStateV(state)
-        self._blockItem.updateSidesFlippedV()
 
     def cancel(self):
         self.close()

--- a/trnsysGUI/BlockItem.py
+++ b/trnsysGUI/BlockItem.py
@@ -168,22 +168,6 @@ class BlockItem(_qtw.QGraphicsItem):  # pylint: disable = too-many-public-method
         self.flippedV = bool(state)
         self._updateTransform()
 
-    def updateSidesFlippedH(self):
-        affectedSides = [0, 2] if self.rotationN % 2 == 0 else [1, 3]
-
-        nQuarterTurnsNeeded = 2
-        self._updatePortSides(nQuarterTurnsNeeded, affectedSides)
-
-    def updateSidesFlippedV(self):
-        affectedSides = [0, 2] if self.rotationN % 2 == 1 else [1, 3]
-
-        nQuarterTurnsNeeded = 2
-        self._updatePortSides(nQuarterTurnsNeeded, affectedSides)
-
-    @staticmethod
-    def _updateSide(port, n):
-        port.side = (port.side + n) % 4
-
     def rotateBlockCW(self):
         self.rotateBlockToN(1)
 
@@ -199,13 +183,8 @@ class BlockItem(_qtw.QGraphicsItem):  # pylint: disable = too-many-public-method
 
     def _rotateBlock(self, nQuarterTurns: int) -> None:
         self.rotationN = nQuarterTurns
-
         self.label.setRotation(-self.rotationN * 90)
-
         self._updateTransform()
-
-        nQuarterTurnsNeeded = nQuarterTurns - self.rotationN
-        self._updatePortSides(nQuarterTurnsNeeded)
 
     def _updateTransform(self) -> None:
         scaleX = -1 if self.flippedH else 1
@@ -223,28 +202,6 @@ class BlockItem(_qtw.QGraphicsItem):  # pylint: disable = too-many-public-method
         transform = scale * translate * rotate  # type: ignore[operator]
 
         self.setTransform(transform)
-
-    def _updatePortSides(
-        self, nQuarterTurnsNeeded: int, affectedSides: _tp.Sequence[_tp.Literal[0, 1, 2, 3]] | None = None
-    ) -> None:
-        if affectedSides is None:
-            affectedSides = [0, 1, 2, 3]
-
-        self._updatePortSidesForPorts(self.inputs, nQuarterTurnsNeeded, affectedSides)
-        self._updatePortSidesForPorts(self.outputs, nQuarterTurnsNeeded, affectedSides)
-
-    def _updatePortSidesForPorts(
-        self,
-        ports: _tp.Sequence[_pib.PortItemBase],
-        nQuarterTurnsNeeded: int,
-        affectedSides: _tp.Sequence[_tp.Literal[0, 1, 2, 3]],
-    ) -> None:
-        for port in ports:
-            if port.side not in affectedSides:
-                continue
-
-            port.itemChange(_qtw.QGraphicsItem.ItemScenePositionHasChanged, port.scenePos())
-            self._updateSide(port, nQuarterTurnsNeeded)
 
     def deleteBlock(self):
         self.editor.trnsysObj.remove(self)

--- a/trnsysGUI/BlockItemFourPorts.py
+++ b/trnsysGUI/BlockItemFourPorts.py
@@ -18,10 +18,10 @@ class BlockItemFourPorts(
 
         self.h = 120
         self.w = 120
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.childIds = []
         self.childIds.append(self.trnsysId)

--- a/trnsysGUI/Boiler.py
+++ b/trnsysGUI/Boiler.py
@@ -16,8 +16,8 @@ class Boiler(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMixin
         self.w = 80
         self.h = 120
         self.portOffset = 5
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -56,11 +56,6 @@ class Boiler(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMixin
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.logger.debug(self.outputs[0].pos())
 
         return w, h
 

--- a/trnsysGUI/CentralReceiver.py
+++ b/trnsysGUI/CentralReceiver.py
@@ -21,8 +21,8 @@ class CentralReceiver(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphic
         self.w = 160
         self.h = 240
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -65,8 +65,5 @@ class CentralReceiver(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphic
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h

--- a/trnsysGUI/Collector.py
+++ b/trnsysGUI/Collector.py
@@ -19,8 +19,8 @@ class Collector(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMi
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -63,8 +63,5 @@ class Collector(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMi
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h

--- a/trnsysGUI/ExternalHx.py
+++ b/trnsysGUI/ExternalHx.py
@@ -56,12 +56,6 @@ class ExternalHx(BlockItemFourPorts):
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
         return w, h
 
     def getInternalPiping(self) -> _ip.InternalPiping:

--- a/trnsysGUI/GenericBlock.py
+++ b/trnsysGUI/GenericBlock.py
@@ -20,8 +20,8 @@ class GenericBlock(_biip.BlockItemHasInternalPiping, _bmx.RasterImageBlockItemMi
         _biip.BlockItemHasInternalPiping.__init__(self, trnsysType, editor, displayName)
         _bmx.RasterImageBlockItemMixin.__init__(self)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.childIds = []
         self.childIds.append(self.trnsysId)
@@ -143,8 +143,8 @@ class GenericBlock(_biip.BlockItemHasInternalPiping, _bmx.RasterImageBlockItemMi
         w = self.w
         delta = 4
         self.logger.debug("side is " + str(side))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", side, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", side, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
         # Allocate id
         self.childIds.append(self.editor.idGen.getTrnsysID())
 

--- a/trnsysGUI/GroundSourceHx.py
+++ b/trnsysGUI/GroundSourceHx.py
@@ -21,8 +21,8 @@ class GroundSourceHx(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicI
         self.w = 60
         self.h = 80
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -61,9 +61,6 @@ class GroundSourceHx(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicI
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 1 + 2 * self.flippedV) % 4
-        self.outputs[0].side = (self.rotationN + 1 + 2 * self.flippedV) % 4
 
         return w, h
 

--- a/trnsysGUI/HPDoubleDual.py
+++ b/trnsysGUI/HPDoubleDual.py
@@ -14,13 +14,13 @@ class HPDoubleDual(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIte
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
 
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         # For restoring correct order of trnsysObj list
         self.childIds = []
@@ -69,13 +69,6 @@ class HPDoubleDual(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIte
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.inputs[2].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[2].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
         return w, h
 
     def encode(self):

--- a/trnsysGUI/HPDual.py
+++ b/trnsysGUI/HPDual.py
@@ -14,11 +14,11 @@ class HPDual(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMixin
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
 
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         # For restoring correct order of trnsysObj list
         self.childIds = []
@@ -64,12 +64,6 @@ class HPDual(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMixin
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h
 

--- a/trnsysGUI/HeatPump.py
+++ b/trnsysGUI/HeatPump.py
@@ -18,11 +18,11 @@ class HeatPump(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMix
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
 
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         # For restoring correct order of trnsysObj list
         self.childIds = []
@@ -70,11 +70,6 @@ class HeatPump(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMix
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
         return w, h
 
     def encode(self):

--- a/trnsysGUI/HeatPumpTwoHx.py
+++ b/trnsysGUI/HeatPumpTwoHx.py
@@ -14,13 +14,13 @@ class HeatPumpTwoHx(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIt
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
 
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         # For restoring correct order of trnsysObj list
         self.childIds = []
@@ -69,13 +69,6 @@ class HeatPumpTwoHx(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIt
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.inputs[2].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[2].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
         return w, h
 
     def encode(self):

--- a/trnsysGUI/IceStorage.py
+++ b/trnsysGUI/IceStorage.py
@@ -15,8 +15,8 @@ class IceStorage(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemM
         super().__init__(trnsysType, editor, displayName)
         self.w = 120
         self.h = 120
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -62,6 +62,4 @@ class IceStorage(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemM
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
         return w, h

--- a/trnsysGUI/IceStorageTwoHx.py
+++ b/trnsysGUI/IceStorageTwoHx.py
@@ -43,12 +43,6 @@ class IceStorageTwoHx(BlockItemFourPorts):
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
         return w, h
 
     def getInternalPiping(self) -> _ip.InternalPiping:

--- a/trnsysGUI/ParabolicTroughField.py
+++ b/trnsysGUI/ParabolicTroughField.py
@@ -16,8 +16,8 @@ class ParabolicTroughField(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGr
 
         self.w = 160
         self.h = 240
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -60,8 +60,5 @@ class ParabolicTroughField(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGr
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h

--- a/trnsysGUI/PitStorage.py
+++ b/trnsysGUI/PitStorage.py
@@ -44,12 +44,6 @@ class PitStorage(BlockItemFourPorts):
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-
         return w, h
 
     def getInternalPiping(self) -> _ip.InternalPiping:

--- a/trnsysGUI/Radiator.py
+++ b/trnsysGUI/Radiator.py
@@ -18,8 +18,8 @@ class Radiator(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMix
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 0, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -64,6 +64,3 @@ class Radiator(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItemMix
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4

--- a/trnsysGUI/SaltTankBase.py
+++ b/trnsysGUI/SaltTankBase.py
@@ -17,8 +17,8 @@ class SaltTankBase(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIte
         self.w = 120
         self.h = 120
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -63,8 +63,5 @@ class SaltTankBase(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIte
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h

--- a/trnsysGUI/SteamPowerBlock.py
+++ b/trnsysGUI/SteamPowerBlock.py
@@ -17,8 +17,8 @@ class SteamPowerBlock(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphic
         self.w = 240
         self.h = 160
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -61,8 +61,5 @@ class SteamPowerBlock(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphic
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return w, h

--- a/trnsysGUI/TVentil.py
+++ b/trnsysGUI/TVentil.py
@@ -30,9 +30,9 @@ class TVentil(
         self.posLabel = _qtw.QGraphicsTextItem(str(self.positionForMassFlowSolver), self)
         self.posLabel.setVisible(False)
 
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
 
         inputPort = _mfn.PortItem("In", _mfn.PortItemDirection.INPUT)
         output1 = _mfn.PortItem("StrOut", _mfn.PortItemDirection.OUTPUT)
@@ -85,10 +85,6 @@ class TVentil(
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 1 + 2 * self.flippedV) % 4
 
         return width, height
 

--- a/trnsysGUI/TVentilDlg.py
+++ b/trnsysGUI/TVentilDlg.py
@@ -94,19 +94,11 @@ class TVentilDlg(_ndialog.ChangeNameDialogBase):
 
         self.okButton.clicked.connect(self.acceptedEdit)
         self.cancelButton.clicked.connect(self.cancel)
-        self.hFlipBox.stateChanged.connect(self.setNewFlipStateH)
-        self.vFlipBox.stateChanged.connect(self.setNewFlipStateV)
+        self.hFlipBox.stateChanged.connect(self._blockItem.updateFlipStateH)
+        self.vFlipBox.stateChanged.connect(self._blockItem.updateFlipStateV)
         self.complexDiv.stateChanged.connect(self.setNewComplexState)
         self.setWindowTitle("Properties")
         self.show()
-
-    def setNewFlipStateH(self, state):
-        self._blockItem.updateFlipStateH(state)
-        self._blockItem.updateSidesFlippedH()
-
-    def setNewFlipStateV(self, state):
-        self._blockItem.updateFlipStateV(state)
-        self._blockItem.updateSidesFlippedV()
 
     def setNewComplexState(self, state):
         self._blockItem.setComplexDiv(state)

--- a/trnsysGUI/components/plugin/factory.py
+++ b/trnsysGUI/components/plugin/factory.py
@@ -168,7 +168,7 @@ class InternalPipingFactory(_plugin.AbstractInternalPipingFactory):
 
     @staticmethod
     def _createPort(
-            portSpec: _smodel.Port, portHelper: _PortPropertiesBase, blockItem: _bi.BlockItem
+        portSpec: _smodel.Port, portHelper: _PortPropertiesBase, blockItem: _bi.BlockItem
     ) -> _pib.PortItemBase:
         match portSpec.type:
             case "standard":

--- a/trnsysGUI/components/plugin/factory.py
+++ b/trnsysGUI/components/plugin/factory.py
@@ -166,33 +166,17 @@ class InternalPipingFactory(_plugin.AbstractInternalPipingFactory):
 
         return graphicalPort, modelInputPort
 
+    @staticmethod
     def _createPort(
-        self, portSpec: _smodel.Port, portHelper: _PortPropertiesBase, blockItem: _bi.BlockItem
+            portSpec: _smodel.Port, portHelper: _PortPropertiesBase, blockItem: _bi.BlockItem
     ) -> _pib.PortItemBase:
-        side = self._getSide(portSpec.position)
-
         match portSpec.type:
             case "standard":
-                return _cspi.createSinglePipePortItem(portHelper.directionLabel, side, blockItem)
+                return _cspi.createSinglePipePortItem(portHelper.directionLabel, blockItem)
             case "hot" | "cold":
-                return _dpi.DoublePipePortItem(portHelper.directionLabel, side, blockItem)
+                return _dpi.DoublePipePortItem(portHelper.directionLabel, blockItem)
             case _:
                 _tp.assert_never(portSpec.type)
-
-    def _getSide(self, portPosition: tuple[int, int]) -> _spi.Side:
-        posX, posY = portPosition
-        width, height = self.specification.size
-
-        if posX == 0:
-            return 0
-        if posY == 0:
-            return 1
-        if posX == width:
-            return 2
-        if posY == height:
-            return 3
-
-        raise ValueError("Invalid port position.", portPosition)
 
     @staticmethod
     def _getDirectionLabel(direction: _mfn.PortItemDirection) -> _tp.Literal["i", "o"]:

--- a/trnsysGUI/connection/connectors/connector.py
+++ b/trnsysGUI/connection/connectors/connector.py
@@ -19,8 +19,8 @@ class Connector(
         self.w = 40
         self.h = 40
 
-        self.fromPort = _cspi.createSinglePipePortItem("i", 0, self)
-        self.toPort = _cspi.createSinglePipePortItem("o", 2, self)
+        self.fromPort = _cspi.createSinglePipePortItem("i", self)
+        self.toPort = _cspi.createSinglePipePortItem("o", self)
 
         self.inputs.append(self.fromPort)
         self.outputs.append(self.toPort)
@@ -79,9 +79,6 @@ class Connector(
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4  # pylint: disable=duplicate-code  # 1
 
         return width, height
 

--- a/trnsysGUI/connection/connectors/doubleDoublePipeConnector.py
+++ b/trnsysGUI/connection/connectors/doubleDoublePipeConnector.py
@@ -16,8 +16,8 @@ class DoubleDoublePipeConnector(_dpcb.DoublePipeConnectorBase):
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.fromPort = _dppi.DoublePipePortItem("i", 0, self)
-        self.toPort = _dppi.DoublePipePortItem("o", 2, self)
+        self.fromPort = _dppi.DoublePipePortItem("i", self)
+        self.toPort = _dppi.DoublePipePortItem("o", self)
 
         self.inputs.append(self.fromPort)
         self.outputs.append(self.toPort)
@@ -46,9 +46,6 @@ class DoubleDoublePipeConnector(_dpcb.DoublePipeConnectorBase):
         # pylint: disable=duplicate-code  # 3
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
     def getInternalPiping(self) -> _ip.InternalPiping:
         coldModelPortItemsToGraphicalPortItem = {

--- a/trnsysGUI/connection/connectors/singleDoublePipeConnector.py
+++ b/trnsysGUI/connection/connectors/singleDoublePipeConnector.py
@@ -17,9 +17,9 @@ class SingleDoublePipeConnector(_dpcb.DoublePipeConnectorBase):
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.outputs.append(_dppi.DoublePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_dppi.DoublePipePortItem("o", self))
 
         self._setModels()
 
@@ -52,11 +52,6 @@ class SingleDoublePipeConnector(_dpcb.DoublePipeConnectorBase):
         # pylint: disable=duplicate-code
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.inputs[1].side = (self.rotationN + 2 * self.flippedH) % 4
-        # pylint: disable=duplicate-code
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
     def getInternalPiping(self) -> _ip.InternalPiping:
         coldModelPortItemsToGraphicalPortItem = {

--- a/trnsysGUI/createSinglePipePortItem.py
+++ b/trnsysGUI/createSinglePipePortItem.py
@@ -10,5 +10,5 @@ if _tp.TYPE_CHECKING:
     import trnsysGUI.BlockItem as _bi
 
 
-def createSinglePipePortItem(name: str, side: _spc.Side, parent: _bi.BlockItem) -> _spc.SinglePipePortItem:
-    return _spc.SinglePipePortItem(name, side, parent, search.getInternallyConnectedPortItems)
+def createSinglePipePortItem(name: str, parent: _bi.BlockItem) -> _spc.SinglePipePortItem:
+    return _spc.SinglePipePortItem(name, parent, search.getInternallyConnectedPortItems)

--- a/trnsysGUI/crystalizer.py
+++ b/trnsysGUI/crystalizer.py
@@ -15,8 +15,8 @@ class Crystalizer(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItem
         self.w = 120
         self.h = 40
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 0, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 2, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -40,10 +40,6 @@ class Crystalizer(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItem
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 0 + 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 + 2 * self.flippedH) % 4
-        # pylint: disable=duplicate-code  # 2
 
     def getInternalPiping(self) -> _ip.InternalPiping:
         inputPort = _mfn.PortItem("In", _mfn.PortItemDirection.INPUT)

--- a/trnsysGUI/heatExchanger.py
+++ b/trnsysGUI/heatExchanger.py
@@ -40,8 +40,8 @@ class HeatExchanger(QGraphicsItemGroup):
 
         self.storageTank.heatExchangers.append(self)
         self.setZValue(100)
-        self.port1 = _cspi.createSinglePipePortItem("i", self.sSide, self.storageTank)
-        self.port2 = _cspi.createSinglePipePortItem("o", self.sSide, self.storageTank)
+        self.port1 = _cspi.createSinglePipePortItem("i", self.storageTank)
+        self.port2 = _cspi.createSinglePipePortItem("o", self.storageTank)
 
         self.storageTank.inputs.append(self.port1)
         self.storageTank.outputs.append(self.port2)

--- a/trnsysGUI/hydraulicLoops/_serialization.py
+++ b/trnsysGUI/hydraulicLoops/_serialization.py
@@ -86,7 +86,7 @@ class _ConnectionsDefinitionModeVersion0(_enum.Enum):
         if self == self.DUMMY_PIPES:
             return _cdm.ConnectionsDefinitionMode.DUMMY_PIPES
 
-        _tp.assert_never(self)
+        raise ValueError("Unknown connections definition mode.", self)
 
 
 @_dc.dataclass

--- a/trnsysGUI/hydraulicLoops/_serialization.py
+++ b/trnsysGUI/hydraulicLoops/_serialization.py
@@ -1,4 +1,5 @@
 import dataclasses as _dc
+import enum as _enum
 import typing as _tp
 import uuid as _uuid
 
@@ -70,29 +71,47 @@ class HydraulicLoopVersion1(_ser.UpgradableJsonSchemaMixin):
         return _uuid.UUID("990b8023-eb4b-408e-8d54-23caa5916b2a")
 
 
+class _ConnectionsDefinitionModeVersion0(_enum.Enum):
+    INDIVIDUAL = _enum.auto()
+    LOOP_WIDE_DEFAULTS = _enum.auto()
+    DUMMY_PIPES = _enum.auto()
+
+    def upgrade(self) -> _cdm.ConnectionsDefinitionMode:
+        if self == self.INDIVIDUAL:
+            return _cdm.ConnectionsDefinitionMode.INDIVIDUAL
+
+        if self == self.LOOP_WIDE_DEFAULTS:
+            return _cdm.ConnectionsDefinitionMode.LOOP_WIDE_DEFAULTS
+
+        if self == self.DUMMY_PIPES:
+            return _cdm.ConnectionsDefinitionMode.DUMMY_PIPES
+
+        _tp.assert_never(self)
+
+
 @_dc.dataclass
-class HydraulicLoop(_ser.UpgradableJsonSchemaMixin):
+class HydraulicLoopVersion2(_ser.UpgradableJsonSchemaMixin):
     name: str
     hasUserDefinedName: bool
     fluidName: str
-    connectionsDefinitionMode: _cdm.ConnectionsDefinitionMode
+    connectionsDefinitionMode: _ConnectionsDefinitionModeVersion0
     connectionsTrnsysId: _tp.Sequence[int]
 
     @classmethod
-    def upgrade(cls, superseded: _ser.UpgradableJsonSchemaMixinVersion0) -> "HydraulicLoop":
+    def upgrade(cls, superseded: _ser.UpgradableJsonSchemaMixinVersion0) -> "HydraulicLoopVersion2":
         assert isinstance(superseded, HydraulicLoopVersion1)
 
-        connectionsEditMode = (
-            _cdm.ConnectionsDefinitionMode.LOOP_WIDE_DEFAULTS
+        connectionsDefinitionMode = (
+            _ConnectionsDefinitionModeVersion0.LOOP_WIDE_DEFAULTS
             if superseded.useLoopWideDefaults
-            else _cdm.ConnectionsDefinitionMode.INDIVIDUAL
+            else _ConnectionsDefinitionModeVersion0.INDIVIDUAL
         )
 
-        return HydraulicLoop(
+        return HydraulicLoopVersion2(
             superseded.name,
             superseded.hasUserDefinedName,
             superseded.fluidName,
-            connectionsEditMode,
+            connectionsDefinitionMode,
             superseded.connectionsTrnsysId,
         )
 
@@ -103,3 +122,32 @@ class HydraulicLoop(_ser.UpgradableJsonSchemaMixin):
     @classmethod
     def getVersion(cls) -> _uuid.UUID:
         return _uuid.UUID("c743e29e-faaa-4e84-bf0f-6a10299097ed")
+
+
+@_dc.dataclass
+class HydraulicLoop(_ser.UpgradableJsonSchemaMixin):
+    name: str
+    hasUserDefinedName: bool
+    fluidName: str
+    connectionsDefinitionMode: _cdm.ConnectionsDefinitionMode
+    connectionsTrnsysId: _tp.Sequence[int]
+
+    @classmethod
+    def upgrade(cls, superseded: _ser.UpgradableJsonSchemaMixinVersion0) -> "HydraulicLoop":
+        assert isinstance(superseded, HydraulicLoopVersion2)
+
+        return HydraulicLoop(
+            superseded.name,
+            superseded.hasUserDefinedName,
+            superseded.fluidName,
+            superseded.connectionsDefinitionMode.upgrade(),
+            superseded.connectionsTrnsysId,
+        )
+
+    @classmethod
+    def getSupersededClass(cls) -> _tp.Type[_ser.UpgradableJsonSchemaMixin]:
+        return HydraulicLoopVersion2
+
+    @classmethod
+    def getVersion(cls) -> _uuid.UUID:
+        return _uuid.UUID("1e16cd15-83b9-46fa-ac63-11b2b2209af1")

--- a/trnsysGUI/hydraulicLoops/connectionsDefinitionMode.py
+++ b/trnsysGUI/hydraulicLoops/connectionsDefinitionMode.py
@@ -2,9 +2,9 @@ import enum as _enum
 
 
 class ConnectionsDefinitionMode(_enum.Enum):
-    INDIVIDUAL = _enum.auto()
-    LOOP_WIDE_DEFAULTS = _enum.auto()
-    DUMMY_PIPES = _enum.auto()
+    INDIVIDUAL = "individual"
+    LOOP_WIDE_DEFAULTS = "loop-wide-defaults"
+    DUMMY_PIPES = "dummy-pipes"
 
     def useLoopWideDefaults(self) -> bool:
         return self == self.LOOP_WIDE_DEFAULTS

--- a/trnsysGUI/pumpsAndTaps/_pumpsAndTabsBase.py
+++ b/trnsysGUI/pumpsAndTaps/_pumpsAndTabsBase.py
@@ -95,27 +95,7 @@ class PumpsAndTabsBase(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphi
         _dfh.moveComponentDdckFolderIfNecessary(self, newName, oldName, self._projectDirPath)
         self.setDisplayName(newName)
 
-        self._setHorizontallyFlipped(newDialogModel.isHorizontallyFlipped)
-        self._setVerticallyFlipped(newDialogModel.isVerticallyFlipped)
+        self.updateFlipStateH(newDialogModel.isHorizontallyFlipped)
+        self.updateFlipStateV(newDialogModel.isVerticallyFlipped)
 
         self.massFlowRateInKgPerH = newDialogModel.massFlowRateKgPerH
-
-    def _setHorizontallyFlipped(self, isHorizontallyFlipped: bool) -> None:
-        wasHorizontallyFlipped = self.flippedH
-        hasHorizontallyFlippedChanged = wasHorizontallyFlipped != isHorizontallyFlipped
-
-        if not hasHorizontallyFlippedChanged:
-            return
-
-        self.updateFlipStateH(isHorizontallyFlipped)
-        self.updateSidesFlippedH()
-
-    def _setVerticallyFlipped(self, isVerticallyFlipped: bool) -> None:
-        wasVerticallyFlipped = self.flippedV
-        hasVerticallyFlippedChanged = wasVerticallyFlipped != isVerticallyFlipped
-
-        if not hasVerticallyFlippedChanged:
-            return
-
-        self.updateFlipStateV(isVerticallyFlipped)
-        self.updateSidesFlippedV()

--- a/trnsysGUI/pumpsAndTaps/_tapBase.py
+++ b/trnsysGUI/pumpsAndTaps/_tapBase.py
@@ -14,12 +14,12 @@ class TapBase(_ptb.PumpsAndTabsBase):
         self._modelTerminal: _mfn.TerminalWithPrescribedFlowBase
 
         if direction == _mfn.PortItemDirection.OUTPUT:
-            self._graphicalPortItem = _cspi.createSinglePipePortItem("o", 0, self)
+            self._graphicalPortItem = _cspi.createSinglePipePortItem("o", self)
             self.outputs.append(self._graphicalPortItem)
             modelPortItem = _mfn.PortItem("Out", _mfn.PortItemDirection.OUTPUT)
             self._modelTerminal = _mfn.TerminalWithPrescribedPosFlow(modelPortItem)
         elif direction == _mfn.PortItemDirection.INPUT:
-            self._graphicalPortItem = _cspi.createSinglePipePortItem("i", 0, self)
+            self._graphicalPortItem = _cspi.createSinglePipePortItem("i", self)
             self.inputs.append(self._graphicalPortItem)
             modelPortItem = _mfn.PortItem("In", _mfn.PortItemDirection.INPUT)
             self._modelTerminal = _mfn.TerminalWithPrescribedNegFlow(modelPortItem)
@@ -71,8 +71,6 @@ class TapBase(_ptb.PumpsAndTabsBase):
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self._graphicalPortItem.side = (self.rotationN + 2 * self.flippedH) % 4
 
         return w, h
 

--- a/trnsysGUI/pumpsAndTaps/pump.py
+++ b/trnsysGUI/pumpsAndTaps/pump.py
@@ -17,8 +17,8 @@ class Pump(_patb.PumpsAndTabsBase):  # pylint: disable=too-many-instance-attribu
     def __init__(self, trnsysType: str, editor, displayName: str) -> None:
         super().__init__(trnsysType, editor, displayName)
 
-        self._fromPort = _cspi.createSinglePipePortItem("i", 0, self)
-        self._toPort = _cspi.createSinglePipePortItem("o", 2, self)
+        self._fromPort = _cspi.createSinglePipePortItem("i", self)
+        self._toPort = _cspi.createSinglePipePortItem("o", self)
 
         self.inputs.append(self._fromPort)
         self.outputs.append(self._toPort)
@@ -112,8 +112,5 @@ class Pump(_patb.PumpsAndTabsBase):  # pylint: disable=too-many-instance-attribu
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
 
         return width, height

--- a/trnsysGUI/sideNrs.py
+++ b/trnsysGUI/sideNrs.py
@@ -1,0 +1,39 @@
+import PyQt5.QtCore as _qtc
+
+import typing as _tp
+
+
+SideNr = _tp.Literal[0, 1, 2, 3]
+
+
+class SideNrs:
+    _ARGS = _tp.get_args(SideNr)
+
+    LEFT = _ARGS[0]
+    BOTTOM = _ARGS[1]
+    RIGHT = _ARGS[2]
+    TOP = _ARGS[3]
+
+
+def getSideNr(portItemRect: _qtc.QRect, blockItemRect: _qtc.QRect) -> SideNr:
+    portItemLeft, portItemRight, portItemTop, portItemBottom = _getLeftRightTopBottom(portItemRect)
+    blockItemLeft, blockItemRight, blockItemTop, blockItemBottom = _getLeftRightTopBottom(blockItemRect)
+
+    if portItemLeft <= blockItemLeft:
+        return SideNrs.LEFT
+    elif portItemRight >= blockItemRight:
+        return SideNrs.RIGHT
+    elif portItemTop <= blockItemTop:
+        return SideNrs.TOP
+    elif portItemBottom >= blockItemBottom:
+        return SideNrs.BOTTOM
+    else:
+        raise AssertionError("Port is inside block item.")
+
+
+def _getLeftRightTopBottom(rect: _qtc.QRect) -> _tp.Tuple[int, int, int, int]:
+    left = rect.x()
+    right = rect.x() + rect.width()
+    top = rect.y()
+    bottom = rect.y() + rect.height()
+    return left, right, top, bottom

--- a/trnsysGUI/sideNrs.py
+++ b/trnsysGUI/sideNrs.py
@@ -1,7 +1,6 @@
-import PyQt5.QtCore as _qtc
-
 import typing as _tp
 
+import PyQt5.QtCore as _qtc
 
 SideNr = _tp.Literal[0, 1, 2, 3]
 
@@ -21,14 +20,17 @@ def getSideNr(portItemRect: _qtc.QRect, blockItemRect: _qtc.QRect) -> SideNr:
 
     if portItemLeft <= blockItemLeft:
         return SideNrs.LEFT
-    elif portItemRight >= blockItemRight:
+
+    if portItemRight >= blockItemRight:
         return SideNrs.RIGHT
-    elif portItemTop <= blockItemTop:
+
+    if portItemTop <= blockItemTop:
         return SideNrs.TOP
-    elif portItemBottom >= blockItemBottom:
+
+    if portItemBottom >= blockItemBottom:
         return SideNrs.BOTTOM
-    else:
-        raise AssertionError("Port is inside block item.")
+
+    raise AssertionError("Port is inside block item.")
 
 
 def _getLeftRightTopBottom(rect: _qtc.QRect) -> _tp.Tuple[int, int, int, int]:

--- a/trnsysGUI/singlePipePortItem.py
+++ b/trnsysGUI/singlePipePortItem.py
@@ -9,18 +9,16 @@ if _tp.TYPE_CHECKING:
     import trnsysGUI.connection.singlePipeConnection as _spc
 
 GetInternallyConnectedPortItems = _tp.Callable[["SinglePipePortItem"], _tp.Sequence["SinglePipePortItem"]]
-Side = _tp.Literal[0, 1, 2, 3]
 
 
 class SinglePipePortItem(_pi.PortItemBase):
     def __init__(
         self,
         name: str,
-        side: Side,
         parent: _bi.BlockItem,
         getInternallyConnectedPortItems: GetInternallyConnectedPortItems,
     ) -> None:
-        super().__init__(name, side, parent)
+        super().__init__(name, parent)
 
         self.getInternallyConnectedPortItems = getInternallyConnectedPortItems
 

--- a/trnsysGUI/sourceSinkBase.py
+++ b/trnsysGUI/sourceSinkBase.py
@@ -18,8 +18,8 @@ class SourceSinkBase(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicI
 
         self.massFlowRateInKgPerH = 500
 
-        self.inputs.append(_cspi.createSinglePipePortItem("i", 1, self))
-        self.outputs.append(_cspi.createSinglePipePortItem("o", 1, self))
+        self.inputs.append(_cspi.createSinglePipePortItem("i", self))
+        self.outputs.append(_cspi.createSinglePipePortItem("o", self))
 
         self.changeSize()
 
@@ -55,9 +55,6 @@ class SourceSinkBase(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicI
 
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
-
-        self.inputs[0].side = (self.rotationN + 1 + 2 * self.flippedV) % 4
-        self.outputs[0].side = (self.rotationN + 1 + 2 * self.flippedV) % 4
 
     def getInternalPiping(self) -> _ip.InternalPiping:
         inputPort = _mfn.PortItem("In", _mfn.PortItemDirection.INPUT)

--- a/trnsysGUI/storageTank/side.py
+++ b/trnsysGUI/storageTank/side.py
@@ -1,5 +1,7 @@
 import enum as _enum
 
+import trnsysGUI.sideNrs as _snrs
+
 
 class Side(_enum.Enum):
     LEFT = "left"
@@ -7,24 +9,24 @@ class Side(_enum.Enum):
 
     @staticmethod
     def createFromSideNr(sideNr: int) -> "Side":
-        if sideNr == 2:
+        if sideNr == _snrs.SideNrs.RIGHT:
             return Side.RIGHT
 
-        if sideNr == 0:
+        if sideNr == _snrs.SideNrs.LEFT:
             return Side.LEFT
 
         raise ValueError(f"Unknown side number: {sideNr}")
 
-    def toSideNr(self):
+    def toSideNr(self) -> _snrs.SideNr:
         if self == self.LEFT:
-            return 0
+            return _snrs.SideNrs.LEFT
 
         if self == self.RIGHT:
-            return 2
+            return _snrs.SideNrs.RIGHT
 
         raise ValueError(f"Cannot convert {self} to side nr.")
 
-    def formatDdck(self):
+    def formatDdck(self) -> str:
         if self == self.LEFT:
             return "Left"
 

--- a/trnsysGUI/storageTank/widget.py
+++ b/trnsysGUI/storageTank/widget.py
@@ -135,13 +135,11 @@ class StorageTank(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicItem
     def _createPort(
         self, name: str, relativeHeight: float, storageTankHeight: float, side: _sd.Side
     ) -> SinglePipePortItem:
-        sideNr = side.toSideNr()
-        portItem = _cspi.createSinglePipePortItem(name, sideNr, self)
+        portItem = _cspi.createSinglePipePortItem(name, self)
         portItem.setZValue(100)
         xPos = 0 if side == _sd.Side.LEFT else self.w
         yPos = storageTankHeight - relativeHeight * storageTankHeight
         portItem.setPos(xPos, yPos)
-        portItem.side = sideNr
         return portItem
 
     @staticmethod

--- a/trnsysGUI/teePieces/doublePipeTeePiece.py
+++ b/trnsysGUI/teePieces/doublePipeTeePiece.py
@@ -35,9 +35,9 @@ class DoublePipeTeePiece(_tpb.TeePieceBase):
 
     def _createInputAndOutputPorts(self) -> _tp.Tuple[_pib.PortItemBase, _pib.PortItemBase, _pib.PortItemBase]:
         return (
-            _dppi.DoublePipePortItem("i", 0, self),
-            _dppi.DoublePipePortItem("o", 2, self),
-            _dppi.DoublePipePortItem("o", 2, self),
+            _dppi.DoublePipePortItem("i", self),
+            _dppi.DoublePipePortItem("o", self),
+            _dppi.DoublePipePortItem("o", self),
         )
 
     def _setModels(self) -> None:

--- a/trnsysGUI/teePieces/teePiece.py
+++ b/trnsysGUI/teePieces/teePiece.py
@@ -27,9 +27,9 @@ class TeePiece(_tpb.TeePieceBase):
 
     def _createInputAndOutputPorts(self) -> _tp.Tuple[_pib.PortItemBase, _pib.PortItemBase, _pib.PortItemBase]:
         return (
-            _cspi.createSinglePipePortItem("i", 0, self),
-            _cspi.createSinglePipePortItem("o", 2, self),
-            _cspi.createSinglePipePortItem("o", 2, self),
+            _cspi.createSinglePipePortItem("i", self),
+            _cspi.createSinglePipePortItem("o", self),
+            _cspi.createSinglePipePortItem("o", self),
         )
 
     def _setModels(self) -> None:

--- a/trnsysGUI/teePieces/teePieceBase.py
+++ b/trnsysGUI/teePieces/teePieceBase.py
@@ -86,10 +86,6 @@ class TeePieceBase(_bip.BlockItemHasInternalPiping, _gimx.SvgBlockItemGraphicIte
         self.updateFlipStateH(self.flippedH)
         self.updateFlipStateV(self.flippedV)
 
-        self.inputs[0].side = (self.rotationN + 2 * self.flippedH) % 4
-        self.outputs[0].side = (self.rotationN + 2 - 2 * self.flippedH) % 4
-        self.outputs[1].side = (self.rotationN + 1 - 2 * self.flippedV) % 4
-
     @property
     def _portOffset(self) -> int:
         raise NotImplementedError()


### PR DESCRIPTION
This allows to get rid off book-keeping need.